### PR TITLE
DERBY - 5849:Text for SQL state XSDG0: remove redundant "page"

### DIFF
--- a/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
+++ b/java/engine/org/apache/derby/iapi/store/raw/PageKey.java
@@ -99,7 +99,8 @@ public final class PageKey
 	}
 
 	public String toString() {
-		return "Page(" + pageNumber + "," + container.toString() + ")";
+		//return "Page(" + pageNumber + "," + container.toString() + ")";
+		return "Could not read page " + pageNumber + " from segment " + container.getSegmentId() + " of container " + container.getContainerId();
 	}
 
 }


### PR DESCRIPTION
The printed statement of the PageKey.toString() is changed.